### PR TITLE
Using limits.sh to discover uint, ulong, llong limits

### DIFF
--- a/src/amg.c
+++ b/src/amg.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <math.h>
 #include <sys/stat.h>
+#include <limits.h>
 #include "c99.h"
 #include "name.h"
 #include "types.h"
@@ -328,7 +329,7 @@ static void amg_setup_mat(
   const uint i0, const uint j0, struct gnz *const p, const uint nz,
   buffer *buf)
 {
-  slong *id = ids->ptr; ulong last_id = -(ulong)1;
+  slong *id = ids->ptr; ulong last_id = ULONG_MAX;
   const uint ne = ids->n;
   uint k,i=0,ie=nloc;
   sarray_sort(struct gnz,p,nz, j,1, buf); /* sort by col */
@@ -677,10 +678,10 @@ static int find_id(
   for(p=data->work.ptr,p_end=p+data->work.n;p!=p_end;++p) {
     while(q!=q_end && q->id<p->id) ++q;
     if(q==q_end) break;
-    if(q->id!=p->id) not_found=1,p->p=-(uint)1;
+    if(q->id!=p->id) not_found=1,p->p=UINT_MAX;
     else p->p=q->p;
   }
-  for(;p!=p_end;++p) not_found=1,p->p=-(uint)1;
+  for(;p!=p_end;++p) not_found=1,p->p=UINT_MAX;
   
   /* send back */
   sarray_transfer(struct find_id_work,&data->work,wp,0,data->cr);
@@ -1141,14 +1142,14 @@ static void mat_list_nonlocal_sorted(
   const struct rnz *p, *const e=(const struct rnz*)mat->ptr+mat->n;
   uint count; struct labelled_rid *out, *end;
   #define BUILD_LIST(k) do { \
-    last_rid.p=-(uint)1,last_rid.i=-(uint)1; \
+    last_rid.p=UINT_MAX,last_rid.i=UINT_MAX; \
     for(count=0,p=mat->ptr;p!=e;++p) { \
       if(p->k.p==pid || rid_equal(last_rid,p->k)) continue; \
       last_rid=p->k; ++count; \
     } \
     array_init(struct labelled_rid, nonlocal_id, count); \
     nonlocal_id->n=count; out=nonlocal_id->ptr; \
-    last_rid.p=-(uint)1,last_rid.i=-(uint)1; \
+    last_rid.p=UINT_MAX,last_rid.i=UINT_MAX; \
     for(p=mat->ptr;p!=e;++p) { \
       if(p->k.p==pid || rid_equal(last_rid,p->k)) continue; \
       (out++)->rid=last_rid=p->k; \

--- a/src/gs_local.c
+++ b/src/gs_local.c
@@ -63,9 +63,9 @@ static void gather_##T##_##OP( \
   const uint *restrict map)                                                  \
 {                                                                            \
   uint i,j;                                                                  \
-  while((i=*map++)!=-(uint)1) {                                              \
+  while((i=*map++)!=UINT_MAX) {                                              \
     T t=out[i];                                                              \
-    j=*map++; do GS_DO_##OP(t,in[j*in_stride]); while((j=*map++)!=-(uint)1); \
+    j=*map++; do GS_DO_##OP(t,in[j*in_stride]); while((j=*map++)!=UINT_MAX); \
     out[i]=t;                                                                \
   }                                                                          \
 }
@@ -80,9 +80,9 @@ static void scatter_##T( \
   const uint *restrict map)                                        \
 {                                                                  \
   uint i,j;                                                        \
-  while((i=*map++)!=-(uint)1) {                                    \
+  while((i=*map++)!=UINT_MAX) {                                    \
     T t=in[i*in_stride];                                           \
-    j=*map++; do out[j*out_stride]=t; while((j=*map++)!=-(uint)1); \
+    j=*map++; do out[j*out_stride]=t; while((j=*map++)!=UINT_MAX); \
   }                                                                \
 }
 
@@ -93,7 +93,7 @@ static void scatter_##T( \
 static void init_##T(T *restrict out, const uint *restrict map, gs_op op) \
 {                                                       \
   uint i; const T e = gs_identity_##T[op];              \
-  while((i=*map++)!=-(uint)1) out[i]=e;                 \
+  while((i=*map++)!=UINT_MAX) out[i]=e;                 \
 }
 
 #define DEFINE_PROCS(T) \
@@ -117,12 +117,12 @@ static void gather_vec_##T##_##OP( \
   const uint *restrict map)                                                  \
 {                                                                            \
   uint i,j;                                                                  \
-  while((i=*map++)!=-(uint)1) {                                              \
+  while((i=*map++)!=UINT_MAX) {                                              \
     T *restrict p = &out[i*vn], *pe = p+vn;                                  \
     j=*map++; do {                                                           \
       const T *restrict q = &in[j*vn];                                       \
       T *restrict pk=p; do { GS_DO_##OP(*pk,*q); ++pk, ++q; } while(pk!=pe); \
-    } while((j=*map++)!=-(uint)1);                                           \
+    } while((j=*map++)!=UINT_MAX);                                           \
   }                                                                          \
 }
 
@@ -135,11 +135,11 @@ void gs_scatter_vec(
 {
   unsigned unit_size = vn*gs_dom_size[dom];
   uint i,j;
-  while((i=*map++)!=-(uint)1) {
+  while((i=*map++)!=UINT_MAX) {
     const char *t = (const char *)in + i*unit_size;
     j=*map++; do
       memcpy((char *)out+j*unit_size,t,unit_size);
-    while((j=*map++)!=-(uint)1);
+    while((j=*map++)!=UINT_MAX);
   }
 }
 
@@ -151,7 +151,7 @@ static void init_vec_##T(T *restrict out, const unsigned vn, \
                          const uint *restrict map, gs_op op) \
 {                                                            \
   uint i; const T e = gs_identity_##T[op];                   \
-  while((i=*map++)!=-(uint)1) {                              \
+  while((i=*map++)!=UINT_MAX) {                              \
     T *restrict u = (T*)out + vn*i, *ue = u+vn;              \
     do *u++ = e; while(u!=ue);                               \
   }                                                          \

--- a/src/sarray_transfer.c
+++ b/src/sarray_transfer.c
@@ -1,6 +1,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#include <limits.h>
 #include "c99.h"
 #include "name.h"
 #include "fail.h"
@@ -27,7 +28,7 @@ static void pack_int(
 
 #define PACK_BODY() do {                                                  \
   uint dummy, *len_ptr=&dummy;                                            \
-  uint i, p,lp = -(uint)1, len=0;                                         \
+  uint i, p,lp = UINT_MAX, len=0;                                         \
   uint *restrict out = buffer_reserve(data, n*(row_size+3)*sizeof(uint)); \
   for(i=0;i<n;++i) {                                                      \
     const char *row = input + size*perm[i];                               \

--- a/src/types.h
+++ b/src/types.h
@@ -1,5 +1,6 @@
 #ifndef TYPES_H
 #define TYPES_H
+#include <limits.h>
 
 /* 
   Define the integer types used throughout the code,
@@ -26,6 +27,11 @@
 
   Since the long long type is not ISO C90, it is never
   used unless explicitly asked for.
+
+  The POSIX-standard limits.h header provides the
+  LLONG_MAX and LLONG_MIN macros, which will be
+  preferentially used.  
+
 */
 
 #if defined(USE_LONG_LONG) || defined(GLOBAL_LONG_LONG)


### PR DESCRIPTION
This PR uses the POSIX-standard `limits.h` header to discover the limits for several variable types in a compliant fashion.  

There are several places where gslib needs to discover the maximum value of an unsigned type.  Currently, it does so via a narrowing type conversion.  For example:
``` C
uint limit = -(uint)1
```
However, these limits are already provided by macros in `limits.h`.  This can avoid possible pitfalls from a narrowing conversion.  A more compliant version (implemented in this PR) looks like:
``` C
#include <limits.h>
uint limit = UINT_MAX
```
There was also one place in `types.h` where `LLONG_MIN` and `LLONG_MAX` were set, if `long long` is requested by the user.  Now, these limits are also taken from `limits.h`
